### PR TITLE
don't have guards deref to `Option<T>`

### DIFF
--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -186,7 +186,12 @@ where
     }
 
     #[inline]
-    pub(crate) fn get(&self, addr: Addr<C>, idx: usize) -> Option<slot::Guard<'_, T, C>> {
+    pub(crate) fn get<U>(
+        &self,
+        addr: Addr<C>,
+        idx: usize,
+        f: impl FnOnce(&T) -> &U,
+    ) -> Option<slot::Guard<'_, U, C>> {
         let poff = addr.offset() - self.prev_sz;
 
         test_println!("-> offset {:?}", poff);
@@ -195,7 +200,7 @@ where
             unsafe { &*slab }
                 .as_ref()?
                 .get(poff)?
-                .get(C::unpack_gen(idx))
+                .get(C::unpack_gen(idx), f)
         })
     }
 

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -99,7 +99,11 @@ where
     }
 
     #[inline(always)]
-    pub(in crate::page) fn get(&self, gen: Generation<C>) -> Option<Guard<'_, T, C>> {
+    pub(in crate::page) fn get<U>(
+        &self,
+        gen: Generation<C>,
+        f: impl FnOnce(&T) -> &U,
+    ) -> Option<Guard<'_, U, C>> {
         let mut lifecycle = self.lifecycle.load(Ordering::Acquire);
         loop {
             // Unpack the current state.
@@ -136,7 +140,7 @@ where
                 Ok(_) => {
                     // Okay, the ref count was incremented successfully! We can
                     // now return a guard!
-                    let item = self.value();
+                    let item = f(self.value());
 
                     test_println!("-> {:?}", new_refs);
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -109,7 +109,7 @@ where
         let tid = C::unpack_tid(key);
 
         test_println!("pool: get{:?}; current={:?}", tid, Tid::<C>::current());
-        let inner = self.shards.get(tid.as_usize())?.get(key)?;
+        let inner = self.shards.get(tid.as_usize())?.get(key, |x| x)?;
 
         Some(PoolGuard {
             inner,

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -48,7 +48,11 @@ where
     C: cfg::Config,
 {
     #[inline(always)]
-    pub(crate) fn get(&self, idx: usize) -> Option<page::slot::Guard<'_, T, C>> {
+    pub(crate) fn get<U>(
+        &self,
+        idx: usize,
+        f: impl FnOnce(&T) -> &U,
+    ) -> Option<page::slot::Guard<'_, U, C>> {
         debug_assert_eq!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
         let (addr, page_index) = page::indices::<C>(idx);
 
@@ -57,7 +61,7 @@ where
             return None;
         }
 
-        self.shared[page_index].get(addr, idx)
+        self.shared[page_index].get(addr, idx, f)
     }
 
     pub(crate) fn new(tid: usize) -> Self {


### PR DESCRIPTION
This commit changes the way the `get` method chain works so that guards
no longer need to dereference to `Option<T>`s when the type returned by
`get` is already an `Option`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>