### PR TITLE
refactor slot initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,8 +271,9 @@ impl<T, C: cfg::Config> Slab<T, C> {
     pub fn insert(&self, value: T) -> Option<usize> {
         let tid = Tid::<C>::current();
         test_println!("insert {:?}", tid);
+        let mut value = Some(value);
         self.shards[tid.as_usize()]
-            .insert(value)
+            .init_with(|slot| slot.insert(&mut value))
             .map(|idx| tid.pack(idx))
     }
 

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -294,7 +294,7 @@ where
     /// This method initializes and sets up the state for a slot. When being used in `Pool`, we
     /// only need to ensure that the `Slot` is in the right state, while when being used in a
     /// `Slab` we want to insert a value into it, as the memory is not initialized
-    pub(super) fn initialize_state(&self, mut f: impl FnMut(&mut T)) -> Option<Generation<C>> {
+    pub(crate) fn initialize_state(&self, f: impl FnOnce(&mut T)) -> Option<Generation<C>> {
         // Load the current lifecycle state.
         let lifecycle = self.lifecycle.load(Ordering::Acquire);
         let gen = LifecycleGen::from_packed(lifecycle).0;
@@ -351,7 +351,7 @@ where
     ///
     /// We first initialize the state and then insert the pased in value into the slot.
     #[inline]
-    pub(super) fn insert(&self, value: &mut Option<T>) -> Option<Generation<C>> {
+    pub(crate) fn insert(&self, value: &mut Option<T>) -> Option<Generation<C>> {
         debug_assert!(self.is_empty(), "inserted into full slot");
         debug_assert!(value.is_some(), "inserted twice");
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -85,11 +85,15 @@ where
     /// let key = pool.create(|item| *item = value.take().expect("created twice")).unwrap();
     /// assert_eq!(pool.get(key).unwrap(), String::from("Hello"));
     /// ```
-    pub fn create(&self, initilizer: impl FnOnce(&mut T)) -> Option<usize> {
+    pub fn create(&self, initializer: impl FnOnce(&mut T)) -> Option<usize> {
         let tid = Tid::<C>::current();
+        let mut init = Some(initializer);
         test_println!("pool: create {:?}", tid);
         self.shards[tid.as_usize()]
-            .get_initialized_slot(initilizer)
+            .init_with(|slot| {
+                let init = init.take().expect("initializer will only be called once");
+                slot.initialize_state(init)
+            })
             .map(|idx| tid.pack(idx))
     }
 
@@ -109,12 +113,7 @@ where
     /// assert_eq!(pool.get(key).unwrap(), String::from("Hello"));
     /// ```
     pub fn create_with(&self, value: T) -> Option<usize> {
-        let tid = Tid::<C>::current();
-        let mut value = Some(value);
-        test_println!("pool: create_with {:?}", tid);
-        self.shards[tid.as_usize()]
-            .get_initialized_slot(move |item| *item = value)
-            .map(|idx| tid.pack(idx))
+        self.create(|t| *t = value)
     }
 
     /// Return a reference to the value associated with the given key.

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -80,9 +80,7 @@ where
     /// ```rust
     /// # use sharded_slab::Pool;
     /// let pool: Pool<String> = Pool::new();
-    /// let mut value = Some(String::from("Hello"));
-    ///
-    /// let key = pool.create(|item| *item = value.take().expect("created twice")).unwrap();
+    /// let key = pool.create(|item| item.push_str("Hello")).unwrap();
     /// assert_eq!(pool.get(key).unwrap(), String::from("Hello"));
     /// ```
     pub fn create(&self, initializer: impl FnOnce(&mut T)) -> Option<usize> {


### PR DESCRIPTION
Currently, there is a lot of code duplication between the slot
initialization functions for the pool and the slab. There are a number
of similar methods that differ only in what `Slot` method they call,
which is a bit confusing when reading the code, and requires duplicating
a lot of common functionality.

I've refactored this code path so that the same `Shard`, page `Shared`
data, and `Slot` methods are used by both the `Pool` and the `Slab`,
with all differences in behavior (namely, which `Slot` method is called)
specified at the callsite. The new implementation has significantly less
code duplication, and is hopefully much clearer.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>